### PR TITLE
Use the document picker exclusively and remove the deprecated menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-FilePicker Phonegap iOS Plugin
+FilePicker PhoneGap iOS Plugin
 ================================
 
 This plugin makes possible to pick files from iCloud or other document providers using a native Document Picker
@@ -72,20 +72,8 @@ var utis = ["public.data", "public.audio"];
 FilePicker.pickFile(successCallback,errorCallback,utis);
 ```
 
-Set the position of the rectangle where the file picker should show up.
-```
-var utis = ["public.data", "public.audio"];
-var position = {};
-position.x = 100;
-position.y = 100;
-position.width = 10;
-position.height = 10;
-FilePicker.pickFile(successCallback,errorCallback,utis,position);
-```
-
-successCallback will bring the file url as string
-errorCallback will bring an error message as string
-
+`successCallback` will return the file url as string.  
+`errorCallback` will return an error message as string.
 
 See all the available UTIs https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-filepicker",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "\n    This plugin makes possible to pick files from iCloud or other document providers\n  ",
   "cordova": {
     "id": "cordova-plugin-filepicker",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-filepicker"
-        version="1.1.4">
+        version="1.2.0">
 
   <name>File Picker</name>
   <author>jcesarmobile</author>

--- a/src/ios/FilePicker.h
+++ b/src/ios/FilePicker.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVPlugin.h>
 
-@interface FilePicker : CDVPlugin <UIDocumentMenuDelegate,UIDocumentPickerDelegate>
+@interface FilePicker : CDVPlugin <UIDocumentPickerDelegate>
 
 @property (strong, nonatomic) CDVPluginResult * pluginResult;
 @property (strong, nonatomic) CDVInvokedUrlCommand * command;

--- a/src/ios/FilePicker.m
+++ b/src/ios/FilePicker.m
@@ -92,16 +92,22 @@
     
 }
 
-- (void)displayDocumentPicker:(NSArray *)UTIs withSenderRect:(CGRect)senderFrame{
+#pragma mark - Internal
+- (void)displayDocumentPicker:(NSArray *)UTIs withSenderRect:(CGRect)senderFrame {
     
-    UIDocumentMenuViewController *importMenu = [[UIDocumentMenuViewController alloc] initWithDocumentTypes:UTIs inMode:UIDocumentPickerModeImport];
-    importMenu.delegate = self;
-    importMenu.popoverPresentationController.sourceView = self.viewController.view;
-    if (!CGRectEqualToRect(senderFrame, CGRectZero)) {
-        importMenu.popoverPresentationController.sourceRect = senderFrame;
+    if (@available(iOS 11.0, *)) {
+        UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:UTIs inMode:UIDocumentPickerModeImport];
+        picker.delegate = self;
+        [self.viewController presentViewController:picker animated:YES completion:nil];
+    } else {
+        UIDocumentMenuViewController *importMenu = [[UIDocumentMenuViewController alloc] initWithDocumentTypes:UTIs inMode:UIDocumentPickerModeImport];
+        importMenu.delegate = self;
+        importMenu.popoverPresentationController.sourceView = self.viewController.view;
+        if (!CGRectEqualToRect(senderFrame, CGRectZero)) {
+            importMenu.popoverPresentationController.sourceRect = senderFrame;
+        }
+        [self.viewController presentViewController:importMenu animated:YES completion:nil];
     }
-    [self.viewController presentViewController:importMenu animated:YES completion:nil];
-    
 }
 
 @end

--- a/src/ios/FilePicker.m
+++ b/src/ios/FilePicker.m
@@ -15,25 +15,10 @@
 }
 
 - (void)pickFile:(CDVInvokedUrlCommand*)command {
-
     self.command = command;
     id UTIs = [command.arguments objectAtIndex:0];
     BOOL supported = YES;
     NSArray * UTIsArray = nil;
-    CGRect frame = CGRectZero;
-
-    if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        if(command.arguments.count > 1) {
-            NSDictionary * frameValues = [command.arguments objectAtIndex:1];
-            frameValues = [frameValues isEqual:[NSNull null]]?nil:frameValues;
-            if (frameValues) {
-                frame.origin.x   = [[frameValues valueForKey:@"x"] integerValue];
-                frame.origin.y   = [[frameValues valueForKey:@"y"] integerValue];
-                frame.size.width = [[frameValues valueForKey:@"width"] integerValue];
-                frame.size.height= [[frameValues valueForKey:@"height"] integerValue];
-            }
-        }
-    }
 
     if ([UTIs isEqual:[NSNull null]]) {
         UTIsArray =  @[@"public.data"];
@@ -54,38 +39,18 @@
     if (supported) {
         self.pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT];
         [self.pluginResult setKeepCallbackAsBool:YES];
-        [self displayDocumentPicker:UTIsArray withSenderRect:frame];
+        [self displayDocumentPicker:UTIsArray];
     }
-    
-}
-
-#pragma mark - UIDocumentMenuDelegate
--(void)documentMenu:(UIDocumentMenuViewController *)documentMenu didPickDocumentPicker:(UIDocumentPickerViewController *)documentPicker {
-    
-    documentPicker.delegate = self;
-    documentPicker.modalPresentationStyle = UIModalPresentationFullScreen;
-    [self.viewController presentViewController:documentPicker animated:YES completion:nil];
-    
-}
-
--(void)documentMenuWasCancelled:(UIDocumentMenuViewController *)documentMenu {
-    
-    self.pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"canceled"];
-    [self.pluginResult setKeepCallbackAsBool:NO];
-    [self.commandDelegate sendPluginResult:self.pluginResult callbackId:self.command.callbackId];
-    
 }
 
 #pragma mark - UIDocumentPickerDelegate
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentAtURL:(NSURL *)url {
-    
     self.pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[url path]];
     [self.pluginResult setKeepCallbackAsBool:NO];
     [self.commandDelegate sendPluginResult:self.pluginResult callbackId:self.command.callbackId];
-    
 }
+
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller {
-    
     self.pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"canceled"];
     [self.pluginResult setKeepCallbackAsBool:NO];
     [self.commandDelegate sendPluginResult:self.pluginResult callbackId:self.command.callbackId];
@@ -93,21 +58,11 @@
 }
 
 #pragma mark - Internal
-- (void)displayDocumentPicker:(NSArray *)UTIs withSenderRect:(CGRect)senderFrame {
-    
-    if (@available(iOS 11.0, *)) {
-        UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:UTIs inMode:UIDocumentPickerModeImport];
-        picker.delegate = self;
-        [self.viewController presentViewController:picker animated:YES completion:nil];
-    } else {
-        UIDocumentMenuViewController *importMenu = [[UIDocumentMenuViewController alloc] initWithDocumentTypes:UTIs inMode:UIDocumentPickerModeImport];
-        importMenu.delegate = self;
-        importMenu.popoverPresentationController.sourceView = self.viewController.view;
-        if (!CGRectEqualToRect(senderFrame, CGRectZero)) {
-            importMenu.popoverPresentationController.sourceRect = senderFrame;
-        }
-        [self.viewController presentViewController:importMenu animated:YES completion:nil];
-    }
+- (void)displayDocumentPicker:(NSArray *)UTIs {
+    UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:UTIs inMode:UIDocumentPickerModeImport];
+    documentPicker.delegate = self;
+    documentPicker.modalPresentationStyle = UIModalPresentationFullScreen;
+    [self.viewController presentViewController:documentPicker animated:YES completion:nil];
 }
 
 @end

--- a/src/ios/FilePicker.m
+++ b/src/ios/FilePicker.m
@@ -10,7 +10,7 @@
 @implementation FilePicker
 
 - (void)isAvailable:(CDVInvokedUrlCommand*)command {
-    BOOL supported = NSClassFromString(@"UIDocumentPickerViewController");
+    BOOL supported = NSClassFromString(@"UIDocumentPickerViewController") != nil;
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:supported] callbackId:command.callbackId];
 }
 

--- a/www/FilePicker.js
+++ b/www/FilePicker.js
@@ -8,8 +8,8 @@
             cordova.exec(success, null, "FilePicker", "isAvailable", []);
         },
   
-        pickFile: function(success, fail,utis, position) {
-            cordova.exec(success, fail, "FilePicker", "pickFile", [utis, position]);
+        pickFile: function(success, fail, utis) {
+            cordova.exec(success, fail, "FilePicker", "pickFile", [utis]);
         }
 
     };


### PR DESCRIPTION
As raised in issue #43, on iOS 11 the action menu contains a single menu item (excluding Cancel) titled Browse (Explorar). 

This is related to iOS 11 deprecating [UIDocumentMenuViewController](https://developer.apple.com/documentation/uikit/uidocumentmenuviewcontroller) in favour of [UIDocumentPickerViewController](https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller) due to the introduction of the Files app on iOS.

This PR replaces the deprecated menu with the picker.

Closes #43.