### PR TITLE
Fix installation error with cordova@9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-filepicker",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "\n    This plugin makes possible to pick files from iCloud or other document providers\n  ",
   "cordova": {
     "id": "cordova-plugin-filepicker",
@@ -22,6 +22,10 @@
       "version": ">=3.0.0"
     }
   ],
+  "dependencies": {
+    "q": "^1.5.1",
+    "xcode": "^2.0.0"
+  },
   "author": "jcesarmobile",
   "license": "MIT",
   "bugs": {

--- a/src/ios/hooks/install_entitlements.js
+++ b/src/ios/hooks/install_entitlements.js
@@ -5,8 +5,8 @@ var fs = require('fs'),
     path = require('path');
 
 module.exports = function (context) {
-  var xcode = context.requireCordovaModule('xcode');
-  var Q = context.requireCordovaModule('q');
+  var xcode = require('xcode');
+  var Q = require('q');
   var deferral = new Q.defer();
 
   if (context.opts.cordova.platforms.indexOf('ios') < 0) {


### PR DESCRIPTION
When attempting to install with Cordova CLI 9, I got an error:
`Using "requireCordovaModule" to load non-cordova module "xcode" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.`
Implementing this recommendation (with both `xcode` and `q`) seems to have fixed the problem.